### PR TITLE
Revert "Use vars dict instead of hostvars[inventory_hostname]"

### DIFF
--- a/tasks/iptables_rule_facts.yml
+++ b/tasks/iptables_rule_facts.yml
@@ -17,7 +17,7 @@
   set_fact:
     iptables_rule_defs: |-
       {% if iptables_search_enabled | bool %}
-      {%   set _rules_search_hits = vars.keys() |
+      {%   set _rules_search_hits = hostvars[inventory_hostname].keys() |
                                     select('match', '^' ~ iptables_search_prefix ~ '.*') |
                                     list
       %}
@@ -25,7 +25,7 @@
       {% set _rules = _rules_search_hits |
                      default([]) |
                      union(iptables_rule_vars) |
-                     map('extract', vars) |
+                     map('extract', hostvars[inventory_hostname]) |
                      sum(start=[]) |
                      list
       %}


### PR DESCRIPTION
Since the hostvars[] dict performs first level templating but vars[]
will not perform any templating, we will continue to use hostvars[]
although in some cases set_fact or vars files may need to be used
if the vars are not present in hostvars.

This reverts commit f39b72ebf34813bca0adbd1aab7fafda5e8c499d.