### PR TITLE
Template missing vars into hostvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note: All of the attributes on rule definitions are _optional_.
 
 ##### Ordering rules allows you to provide higher precedence overrides, for example we will override the default firewall in `vars/firewall_base.yml` to change the INPUT chain policy to "ACCEPT" instead of "DENY".
 ```yaml
-# THe default order of '50' will override the firewall_base order value of '9999'.
+# The default order of '50' will override the firewall_base order value of '9999'.
 - hosts: all
   vars:
     iptables_rule_definitions:

--- a/tasks/iptables_rule_facts.yml
+++ b/tasks/iptables_rule_facts.yml
@@ -13,6 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Playbook vars are not templated into hostvars, however they are stored in the
+# dict called "vars" without any jinja resolved. This will set_fact them into
+# hostvars and resolve any jinja in the process.
+- name: Set facts for the firewall search results missing from hostvars
+  set_fact:
+    "{{ item }}": "{{ vars[item] }}"
+  when:
+    - iptables_search_enabled | bool
+    - item not in hostvars[inventory_hostname].keys()
+  with_items: "{{ vars.keys() | select('match', '^' ~ iptables_search_prefix ~ '.*') | list }}"
+
 - name: Build a list of rules defined in hostvars
   set_fact:
     iptables_rule_defs: |-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -35,6 +35,9 @@
           - "{{ iptables_save_output | regex_replace('(.*\\*filter.*:INPUT DROP.*COMMIT.*)', 'true') | bool }}"
           # Ensure rules exist in the DEFAULT_RULES chain
           - "{{ '-A DEFAULT_RULES' in iptables_save_output.stdout }}"
+          # Test playbook chains
+          - "{{ ':PLAYBOOK_NO_JINJA' in iptables_save_output.stdout }}"
+          - "{{ ':PLAYBOOK_TEMPLATED_CHAIN' in iptables_save_output.stdout }}"
     - name: Check ip6tables operational status
       assert:
         that:
@@ -42,3 +45,11 @@
           - "{{ ip6tables_save_output | regex_replace('(.*\\*filter.*:INPUT DROP.*COMMIT.*)', 'true') | bool }}"
           # Ensure rules exist in the DEFAULT_RULES chain
           - "{{ '-A DEFAULT_RULES' in ip6tables_save_output.stdout }}"
+  vars:
+    firewall_playbook_chain_notemplate:
+      - chains:
+          - name: PLAYBOOK_NO_JINJA
+    playbook_templated_chain: PLAYBOOK_TEMPLATED_CHAIN
+    firewall_playbook_chain_template:
+      - chains:
+          - name: "{{ playbook_templated_chain }}"


### PR DESCRIPTION
Some vars, such as playbook vars, are not loaded into the hostvars
dict. They are present in the vars dict without any jinja templating
resolved[1][2].

We will now load these missing vars into hostvars using set_fact,
which will cause any templating inside the var to be resolved.

[1] f39b72ebf34813bca0adbd1aab7fafda5e8c499d
[2] 9049b2f9a442e75fa0b487b469cf35d403208186