### PR TITLE
Allow rule defs to define rules as a string

### DIFF
--- a/templates/default.j2
+++ b/templates/default.j2
@@ -17,8 +17,10 @@
 {%   for rule in iptables_rules |
                   selectattr('table', 'equalto', table) |
                   map(attribute='rules') |
-                  select('defined') |
-                  sum(start=[]) %}
+                  select('defined') %}
+{%     if rule is not string %}
+{%       set rule = rule | join('\n') %}
+{%     endif %}
 {{ rule }}
 {%   endfor %}
 COMMIT

--- a/tests/group_vars/test_containers.yml
+++ b/tests/group_vars/test_containers.yml
@@ -1,0 +1,31 @@
+---
+# Copyright 2017, Logan Vig <logan2211@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test templated firweall search from group vars
+group_templated_chain: GROUP_VAR_TEMPLATED_CHAIN
+firewall_group_vars_templated:
+  - chains:
+      - name: "{{ group_templated_chain }}"
+
+firewall_testing:
+  # Test rules as strings
+  - chains:
+      - name: STRING_RULES
+    rules: |
+      -A STRING_RULES -j ACCEPT
+  - chains:
+      - name: LIST_RULES
+    rules:
+      - '-A LIST_RULES -j ACCEPT'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -35,6 +35,9 @@
           - "{{ iptables_save_output | regex_replace('(.*\\*filter.*:INPUT DROP.*COMMIT.*)', 'true') | bool }}"
           # Ensure rules exist in the DEFAULT_RULES chain
           - "{{ '-A DEFAULT_RULES' in iptables_save_output.stdout }}"
+          # Test string/list based rules
+          - "{{ '-A STRING_RULES' in iptables_save_output.stdout }}"
+          - "{{ '-A LIST_RULES' in iptables_save_output.stdout }}"
     - name: Check ip6tables operational status
       assert:
         that:


### PR DESCRIPTION
Previously a list was required, but in some cases a string may be
preferred.

Multi-line strings are accepted to allow multiple rules defined in
one string.