### PR TITLE
Update to stop deprecation warning:

### DIFF
--- a/tasks/iptables_install_apt.yml
+++ b/tasks/iptables_install_apt.yml
@@ -15,8 +15,7 @@
 
 - name: Install the iptables OS Packages
   apt:
-    name: "{{ item }}"
+    name: "{{ iptables_distro_packages }}"
     state: "{{ iptables_package_state }}"
     update_cache: yes
     cache_valid_time: "{{ cache_timeout }}"
-  with_items: "{{ iptables_distro_packages }}"

--- a/tasks/iptables_install_yum.yml
+++ b/tasks/iptables_install_yum.yml
@@ -15,7 +15,5 @@
 
 - name: Install iptables OS packages (yum)
   yum:
-    name: "{{ item }}"
+    name: "{{ iptables_distro_packages }}"
     state: "{{ iptables_package_state }}"
-  with_items:
-    - "{{ iptables_distro_packages }}"


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: "{{ item }}"`, please use `name: '{{iptables_distro_packages }}'`
and remove the loop. This feature will be removed in version 2.11. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.