### PR TITLE
Fix vars templating on ansible 2.8 and later

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Note: All of the attributes on rule definitions are _optional_.
 
 ##### Ordering rules allows you to provide higher precedence overrides, for example we will override the default firewall in `vars/firewall_base.yml` to change the INPUT chain policy to "ACCEPT" instead of "DENY".
 ```yaml
-# THe default order of '50' will override the firewall_base order value of '9999'.
+# The default order of '50' will override the firewall_base order value of '9999'.
 - hosts: all
   vars:
     iptables_rule_definitions:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,11 @@
   hosts: all
   roles:
     - role: "{{ playbook_dir | dirname | dirname | basename }}"
+  vars:
+    firewall_playbook_chain_notemplate:
+      - chains:
+          - name: PLAYBOOK_NO_JINJA
+    playbook_templated_chain: PLAYBOOK_TEMPLATED_CHAIN
+    firewall_playbook_chain_template:
+      - chains:
+          - name: "{{ playbook_templated_chain }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -28,6 +28,9 @@
           # Test string/list based rules
           - "{{ '-A STRING_RULES' in iptables_save_output.stdout }}"
           - "{{ '-A LIST_RULES' in iptables_save_output.stdout }}"
+          # Test playbook chains
+          - "{{ ':PLAYBOOK_NO_JINJA' in iptables_save_output.stdout }}"
+          - "{{ ':PLAYBOOK_TEMPLATED_CHAIN' in iptables_save_output.stdout }}"
     - name: Check ip6tables operational status
       assert:
         that:
@@ -35,3 +38,6 @@
           - "{{ ip6tables_save_output | regex_replace('(.*\\*filter.*:INPUT DROP.*COMMIT.*)', 'true') | bool }}"
           # Ensure rules exist in the DEFAULT_RULES chain
           - "{{ '-A DEFAULT_RULES' in ip6tables_save_output.stdout }}"
+          # Test playbook chains
+          - "{{ ':PLAYBOOK_NO_JINJA' in iptables_save_output.stdout }}"
+          - "{{ ':PLAYBOOK_TEMPLATED_CHAIN' in iptables_save_output.stdout }}"

--- a/tasks/iptables_rule_facts.yml
+++ b/tasks/iptables_rule_facts.yml
@@ -41,10 +41,10 @@
       {%   set _order = _rule_def.order | default(50) | int %}
       {%   set _table = _rule_def.table | default('filter') %}
       {%   set _ = _rule_def.update({
-            'protocol': _protocol,
-            'order': _order,
-            'table': _table
-          })
+             'protocol': _protocol,
+             'order': _order,
+             'table': _table
+           })
       %}
       {%   set _ = _var.append(_rule_def) %}
       {% endfor %}

--- a/tasks/iptables_rule_facts.yml
+++ b/tasks/iptables_rule_facts.yml
@@ -17,31 +17,34 @@
   set_fact:
     iptables_rule_defs: |-
       {% if iptables_search_enabled | bool %}
-      {%   set _rules_search_hits = hostvars[inventory_hostname].keys() |
+      {%   set _rules_search_hits = vars.keys() |
                                     select('match', '^' ~ iptables_search_prefix ~ '.*') |
                                     list
       %}
       {% endif %}
-      {% set _rules = _rules_search_hits |
-                     default([]) |
-                     union(iptables_rule_vars) |
-                     map('extract', hostvars[inventory_hostname]) |
-                     sum(start=[]) |
-                     list
-      %}
-      {% set _rules = _rules | union(iptables_rule_definitions) %}
+      {# Add the static rule definitions #}
+      {% set _rules = iptables_rule_definitions %}
+      {# Add rules from search vars (ie. firewall_*) and also a list of vars
+         defined in iptables_rule_vars
+      #}
+      {% for _rule in _rules_search_hits |
+                      default([]) |
+                      union(iptables_rule_vars) |
+                      list %}
+      {%   set _ = _rules.append(lookup('vars', _rule)) %}
+      {% endfor %}
       {# Since the 'order' attribute is optional we need to loop thru #}
       {# and default it if it is not defined before sorting. #}
       {% set _var = [] %}
-      {% for _rule_def in _rules %}
+      {% for _rule_def in _rules | sum(start=[]) %}
       {%   set _protocol = _rule_def.protocol | default('ipv4') %}
       {%   set _order = _rule_def.order | default(50) | int %}
       {%   set _table = _rule_def.table | default('filter') %}
       {%   set _ = _rule_def.update({
-             'protocol': _protocol,
-             'order': _order,
-             'table': _table
-           })
+            'protocol': _protocol,
+            'order': _order,
+            'table': _table
+          })
       %}
       {%   set _ = _var.append(_rule_def) %}
       {% endfor %}


### PR DESCRIPTION
On ansible 2.8 and later, vars are not automatically rendered into
hostvars, especially when referencing variables on other inventory
hosts. Playbook vars are also not present in hostvars.

By searching the 'vars' dict instead of 'hostvars' for rules, a
full list of variables can be obtained. From there, templating the
contents of the variable can be done using lookup('vars', varname).

This patch refactors the rule generation to use the vars lookup
plugin to properly template all rules on ansible 2.8 and later.

Closes #8